### PR TITLE
Fix: Update favicon and login page images with web URLs

### DIFF
--- a/src/app/features/auth/login/login.component.html
+++ b/src/app/features/auth/login/login.component.html
@@ -4,7 +4,7 @@
     <div class="col-md-6 login-form-container">
       <div class="login-form">
         <div class="text-center mb-4">
-          <img src="assets/images/logo.png" alt="School Management System" class="logo mb-4" />
+          <img src="https://i.etsystatic.com/26375241/r/il/c58701/3180068615/il_1080xN.3180068615_bbus.jpg" alt="School Management System" class="logo mb-4" />
           <h2 class="welcome-text">Welcome Back!</h2>
           <p class="text-muted">Please login to your account</p>
         </div>

--- a/src/app/features/auth/login/login.component.ts
+++ b/src/app/features/auth/login/login.component.ts
@@ -37,9 +37,9 @@ export class LoginComponent implements OnInit {
       this.navigateByRole();
     }
     this.carouselSlides = [
-      { image: 'https://placehold.co/1200x800/0056b3/FFFFFF?text=Empowering+Students', alt: 'Empowering Students', description: 'Empowering Students' },
-      { image: 'https://placehold.co/1200x800/28a745/FFFFFF?text=Real-time+Tracking', alt: 'Real-time Performance Tracking', description: 'Real-time Performance Tracking' },
-      { image: 'https://placehold.co/1200x800/6f42c1/FFFFFF?text=Seamless+Communication', alt: 'Seamless Communication', description: 'Seamless Communication' }
+      { image: 'https://cdni.iconscout.com/illustration/premium/thumb/school-girl-saying-good-bye-to-teacher-illustration-download-in-svg-png-gif-file-formats--building-waiving-hand-pack-people-illustrations-3697284.png?f=webp', alt: 'Empowering Students', description: 'Empowering Students' },
+      { image: 'https://cdni.iconscout.com/illustration/premium/thumb/girl-reading-book-in-school-library-illustration-download-svg-png-gif-file-formats--student-activities-pack-education-illustrations-3561229.png?f=webp', alt: 'Real-time Performance Tracking', description: 'Real-time Performance Tracking' },
+      { image: 'https://cdni.iconscout.com/illustration/premium/thumb/a-group-of-student-standing-together-and-discussing-after-school-illustration-download-in-svg-png-gif-file-formats--backpack-book-boy-characters-study-education-pack-illustrations-1819840.png?f=webp', alt: 'Seamless Communication', description: 'Seamless Communication' }
     ];
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <title>School Management System</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/jpeg" href="https://i.etsystatic.com/26375241/r/il/c58701/3180068615/il_1080xN.3180068615_bbus.jpg">
   <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://getbootstrap.com/docs/5.3/assets/css/docs.css" rel="stylesheet"> -->


### PR DESCRIPTION
- Favicon: Updated src/index.html to use an external URL for the favicon as requested.
- Login Page Logo: Updated the logo image in login.component.html to use an external URL.
- Login Page Carousel: Updated carousel images in login.component.ts to use specified external IconScout URLs.
- Cleanup: Removed the old local logo.png as it's no longer referenced after these changes.