### PR TITLE
Feat: Implement color picker theme selection across dashboards

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -79,12 +79,13 @@ export class AuthService {
 
     if (userData.preferredTheme !== undefined) {
       // API call to update theme
-      // API call to update theme. Expects payload like {"preferredTheme": "#RRGGBB"}
-      // and returns the updated UserDTO.
-      return this.http.put<User>(`${environment.apiUrl}/users/me/theme`, { preferredTheme: userData.preferredTheme })
+      // API call to update theme. Expects payload like {"theme": "#RRGGBB"}
+      // and returns the updated UserDTO (which will have "preferredTheme").
+      return this.http.put<User>(`${environment.apiUrl}/users/me/theme`, { theme: userData.preferredTheme }) // Use "theme" as key in request body
         .pipe(
           tap((updatedUserFromApi) => {
-            // API returns the full updated UserDTO. Use this as the source of truth.
+            // API returns the full updated UserDTO. This response should contain the persisted 'preferredTheme'.
+            // Update local state with the full, fresh user object from the API.
             this.currentUserSubject.next(updatedUserFromApi);
             localStorage.setItem('current_user', JSON.stringify(updatedUserFromApi));
             console.log('User theme updated via API and locally:', updatedUserFromApi);

--- a/src/app/features/dashboard/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/features/dashboard/admin-dashboard/admin-dashboard.component.html
@@ -55,6 +55,14 @@
           <i class="bi bi-list"></i>
         </button>
         <div class="ms-auto d-flex align-items-center">
+           <!-- Color Picker for Theme -->
+           <div class="me-3 d-flex align-items-center">
+            <label for="themeColorPickerAdmin" class="form-label me-2 mb-0 d-none d-md-inline">Theme:</label>
+            <input type="color" class="form-control form-control-color" id="themeColorPickerAdmin"
+                   [value]="currentThemeColor"
+                   (input)="onThemeColorChange($event)"
+                   title="Select theme color">
+          </div>
           <div class="dropdown">
             <button class="btn btn-link dropdown-toggle" type="button" id="userDropdown" data-bs-toggle="dropdown">
               <i class="bi bi-person-circle"></i>

--- a/src/app/features/dashboard/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/features/dashboard/admin-dashboard/admin-dashboard.component.ts
@@ -53,6 +53,11 @@ export class AdminDashboardComponent extends BaseDashboardComponent {
     return userRole === 'ADMIN';
   }
 
+  onThemeColorChange(event: Event): void {
+    const color = (event.target as HTMLInputElement).value;
+    this.selectThemeColor(color); // Call method from BaseDashboardComponent
+  }
+
   // Placeholder methods for Quick Actions - to be updated if APIs are available
   addNewTeacher(): void {
     this.snackbarService.show('Add New Teacher API not yet implemented.', 'info');

--- a/src/app/features/dashboard/student-dashboard/student-dashboard.component.html
+++ b/src/app/features/dashboard/student-dashboard/student-dashboard.component.html
@@ -55,6 +55,14 @@
         </button>
         <!-- Removed static title, can be added back if needed or handled by a breadcrumb service -->
         <div class="ms-auto d-flex align-items-center"> <!-- ms-auto to push dropdown to right -->
+            <!-- Color Picker for Theme -->
+            <div class="me-3 d-flex align-items-center">
+                <label for="themeColorPickerStudent" class="form-label me-2 mb-0 d-none d-md-inline">Theme:</label>
+                <input type="color" class="form-control form-control-color" id="themeColorPickerStudent"
+                       [value]="currentThemeColor"
+                       (input)="onThemeColorChange($event)"
+                       title="Select theme color">
+            </div>
             <div class="dropdown">
                 <button class="btn btn-link dropdown-toggle" type="button" id="userDropdown" data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="bi bi-person-circle"></i> <!-- Changed icon -->

--- a/src/app/features/dashboard/student-dashboard/student-dashboard.component.ts
+++ b/src/app/features/dashboard/student-dashboard/student-dashboard.component.ts
@@ -54,6 +54,11 @@ export class StudentDashboardComponent extends BaseDashboardComponent {
     return userRole === 'STUDENT';
   }
 
+  onThemeColorChange(event: Event): void {
+    const color = (event.target as HTMLInputElement).value;
+    this.selectThemeColor(color); // Call method from BaseDashboardComponent
+  }
+
   // Placeholder methods for Quick Actions - to be updated if APIs are available
   viewCourses(): void {
     this.snackbarService.show('View Courses API not yet implemented.', 'info');

--- a/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.html
+++ b/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.html
@@ -66,18 +66,13 @@
           <i class="bi bi-list"></i>
         </button>
         <div class="ms-auto d-flex align-items-center">
-          <!-- Theme Selector Dropdown -->
-          <div class="dropdown me-3">
-            <button class="btn btn-link dropdown-toggle" type="button" id="themeDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-              <i class="bi bi-palette"></i> <span class="d-none d-md-inline">Theme</span>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeDropdown">
-              <li><button class="dropdown-item" type="button" (click)="selectTheme('DEFAULT')">Default</button></li>
-              <li><button class="dropdown-item" type="button" (click)="selectTheme('SUPER_ADMIN')">Navy Blue</button></li>
-              <li><button class="dropdown-item" type="button" (click)="selectTheme('ADMIN')">Deep Green</button></li>
-              <li><button class="dropdown-item" type="button" (click)="selectTheme('TEACHER')">Indigo</button></li>
-              <li><button class="dropdown-item" type="button" (click)="selectTheme('STUDENT')">Teal</button></li>
-            </ul>
+          <!-- Color Picker for Theme -->
+          <div class="me-3 d-flex align-items-center">
+            <label for="themeColorPicker" class="form-label me-2 mb-0 d-none d-md-inline">Theme:</label>
+            <input type="color" class="form-control form-control-color" id="themeColorPicker"
+                   [value]="currentThemeColor"
+                   (input)="onThemeColorChange($event)"
+                   title="Select theme color">
           </div>
 
           <!-- User Profile Dropdown -->

--- a/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.ts
+++ b/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.ts
@@ -410,9 +410,12 @@ export class SuperAdminDashboardComponent extends BaseDashboardComponent impleme
     return userRole === 'SUPER_ADMIN';
   }
 
-  selectTheme(themeName: string): void {
-    this.themeService.setTheme(themeName);
+  onThemeColorChange(event: Event): void {
+    const color = (event.target as HTMLInputElement).value;
+    this.selectThemeColor(color); // Call method from BaseDashboardComponent
   }
+
+  // Old selectTheme(themeName: string) method removed as it's replaced by color picker.
 
   // Action methods from Overview Tab
   addNewSchool(): void {

--- a/src/app/features/dashboard/teacher-dashboard/teacher-dashboard.component.html
+++ b/src/app/features/dashboard/teacher-dashboard/teacher-dashboard.component.html
@@ -60,6 +60,14 @@
           <i class="bi bi-list"></i>
         </button>
         <div class="ms-auto d-flex align-items-center">
+          <!-- Color Picker for Theme -->
+          <div class="me-3 d-flex align-items-center">
+            <label for="themeColorPickerTeacher" class="form-label me-2 mb-0 d-none d-md-inline">Theme:</label>
+            <input type="color" class="form-control form-control-color" id="themeColorPickerTeacher"
+                   [value]="currentThemeColor"
+                   (input)="onThemeColorChange($event)"
+                   title="Select theme color">
+          </div>
           <div class="me-3">
             <span class="badge bg-success">Online</span>
           </div>

--- a/src/app/features/dashboard/teacher-dashboard/teacher-dashboard.component.ts
+++ b/src/app/features/dashboard/teacher-dashboard/teacher-dashboard.component.ts
@@ -50,6 +50,11 @@ export class TeacherDashboardComponent extends BaseDashboardComponent {
     return userRole === 'TEACHER';
   }
 
+  onThemeColorChange(event: Event): void {
+    const color = (event.target as HTMLInputElement).value;
+    this.selectThemeColor(color); // Call method from BaseDashboardComponent
+  }
+
   // Quick Actions - to be updated if APIs are available
   createAssignment(): void {
     this.snackbarService.show('Create Assignment API not yet implemented.', 'info');


### PR DESCRIPTION
- AuthService: Modified `updateCurrentUserProfile` to send `{"theme": "colorCode"}` payload for `PUT /users/me/theme` API call, as per clarification. It correctly updates local user state with `preferredTheme` from API response.
- BaseDashboardComponent: Added `ThemeService` injection. Added `currentThemeColor` property for color picker binding, kept in sync with `AuthService.currentUser.preferredTheme`. Added `selectThemeColor(color)` method to call `ThemeService.setTheme()`.
- Dashboard Templates (Super Admin, Admin, Teacher, Student): Added `<input type="color">` to top navigation. Bound its value to `currentThemeColor` and its input event to `onThemeColorChange()` which calls the base `selectThemeColor()`.
- Super Admin Dashboard: Removed old theme dropdown UI and its corresponding `selectTheme(themeName: string)` method.
- ThemeService: Confirmed existing logic correctly handles applying a single color code (from `user.preferredTheme`) to CSS variables and triggers `AuthService` for persistence.
- Models & Error Fixes: Addressed various model import issues, duplicate imports, and ensured `CommonModule` for `JsonPipe`. Corrected `schoolId` access in `SuperAdminDashboardComponent`.
- Data Services: Cleaned up dashboard data services to remove calls to non-existent overview APIs, aligning with current backend status.