### PR TITLE
Refactor: Remove redundant top tab navigation

### DIFF
--- a/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.html
+++ b/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.html
@@ -101,30 +101,11 @@
     <!-- Dashboard Content -->
     <div class="content-wrapper">
       <div class="container-fluid">
-        <!-- Tab Navigation -->
-        <ul class="nav nav-tabs mb-3" id="superAdminTabs" role="tablist">
-          <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="overview-tab" data-bs-toggle="tab" data-bs-target="#overview" type="button" role="tab" aria-controls="overview" aria-selected="true">Overview</button>
-          </li>
-          <li class="nav-item" role="presentation">
-            <button class="nav-link" id="manage-schools-tab" data-bs-toggle="tab" data-bs-target="#manage-schools" type="button" role="tab" aria-controls="manage-schools" aria-selected="false">Manage Schools</button>
-          </li>
-          <li class="nav-item" role="presentation">
-            <button class="nav-link" id="manage-principals-tab" data-bs-toggle="tab" data-bs-target="#manage-principals" type="button" role="tab" aria-controls="manage-principals" aria-selected="false">Manage Principals</button>
-          </li>
-          <li class="nav-item" role="presentation">
-            <button class="nav-link" id="manage-teachers-tab" data-bs-toggle="tab" data-bs-target="#manage-teachers" type="button" role="tab" aria-controls="manage-teachers" aria-selected="false">Manage Teachers</button>
-          </li>
-          <li class="nav-item" role="presentation">
-            <button class="nav-link" id="view-students-tab" data-bs-toggle="tab" data-bs-target="#view-students" type="button" role="tab" aria-controls="view-students" aria-selected="false">View Students</button>
-          </li>
-          <li class="nav-item" role="presentation">
-            <button class="nav-link" id="reports-stats-tab" data-bs-toggle="tab" data-bs-target="#reports-stats" type="button" role="tab" aria-controls="reports-stats" aria-selected="false">Reports/Statistics</button>
-          </li>
-        </ul>
+        <!-- Tab Navigation Removed -->
 
         <!-- Tab Content Area -->
-        <div class="tab-content p-3" id="superAdminTabContent">
+        <!-- Ensure p-3 or similar padding is maintained if needed, or add pt-3 to content sections if mb-3 from nav-tabs was important -->
+        <div class="tab-content pt-3" id="superAdminTabContent">
 
           <!-- Overview Tab Content -->
           <div *ngIf="isOverviewActive" class="tab-pane fade show active" id="overview" role="tabpanel" aria-labelledby="overview-tab">
@@ -728,6 +709,7 @@
         </div>
 
       </div> <!-- End of container-fluid -->
+    </div>
     </div> <!-- End of content-wrapper -->
   </main>
 </div>

--- a/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.ts
+++ b/src/app/features/dashboard/super-admin-dashboard/super-admin-dashboard.component.ts
@@ -76,7 +76,7 @@ export class SuperAdminDashboardComponent extends BaseDashboardComponent impleme
   ];
 
   activeTab: SuperAdminTabName = 'overview'; // Default to overview tab
-  private tabInstances: { [key: string]: any } = {};
+  // private tabInstances: { [key: string]: any } = {}; // No longer needed
 
 
   constructor(
@@ -118,7 +118,7 @@ export class SuperAdminDashboardComponent extends BaseDashboardComponent impleme
       this.teacherModal = new bootstrap.Modal(teacherModalElement);
     }
     this.initTeacherForm(); // Init teacher form
-    this.initializeTabs();
+-    // this.initializeTabs(); // No longer needed
   }
 
   // loadSuperAdminDashboardData(): void {
@@ -150,25 +150,26 @@ export class SuperAdminDashboardComponent extends BaseDashboardComponent impleme
   //   });
   // }
 
-  initializeTabs(): void {
-    ['overview', 'manage-schools', 'manage-principals', 'manage-teachers', 'view-students', 'reports-stats'].forEach(tabId => {
-      const tabElement = document.getElementById(`${tabId}-tab`);
-      if (tabElement) {
-        this.tabInstances[tabId] = new bootstrap.Tab(tabElement);
-      }
-    });
-    // Ensure the default activeTab is shown
-    if (this.tabInstances[this.activeTab]) {
-       // Timeout to ensure elements are fully rendered before trying to show tab
-      setTimeout(() => this.tabInstances[this.activeTab]?.show(), 0);
-    }
-  }
+  // initializeTabs(): void { // Method no longer needed as top tabs are removed
+  //   ['overview', 'manage-schools', 'manage-principals', 'manage-teachers', 'view-students', 'reports-stats'].forEach(tabId => {
+  //     const tabElement = document.getElementById(`${tabId}-tab`);
+  //     if (tabElement) {
+  //       this.tabInstances[tabId] = new bootstrap.Tab(tabElement);
+  //     }
+  //   });
+  //   // Ensure the default activeTab is shown
+  //   if (this.tabInstances[this.activeTab]) {
+  //      // Timeout to ensure elements are fully rendered before trying to show tab
+  //     setTimeout(() => this.tabInstances[this.activeTab]?.show(), 0);
+  //   }
+  // }
 
   setActiveTab(tabId: SuperAdminTabName): void {
     this.activeTab = tabId;
-    if (this.tabInstances[tabId]) {
-      this.tabInstances[tabId].show();
-    }
+    // The following lines related to Bootstrap tab instances are no longer needed
+    // if (this.tabInstances[tabId]) {
+    //   this.tabInstances[tabId].show();
+    // }
     if (this.isMobileView) { // Close mobile sidebar on tab navigation
         this.closeMobileSidebar();
     }


### PR DESCRIPTION
- Deleted the HTML for the top nav-tabs UI in the main content area.
- Commented out the `tabInstances` property, the `initializeTabs()` method, and related logic in `setActiveTab()` in the component TypeScript, as these were specific to the removed Bootstrap tab UI.

This change simplifies the UI by relying solely on the left sidebar for tab navigation.